### PR TITLE
Adding esc_url to address potential security issue

### DIFF
--- a/resend-welcome-email.php
+++ b/resend-welcome-email.php
@@ -124,10 +124,10 @@ if ( !class_exists( 'Resend_Welcome_Email' )) {
 		 */
 		public static function send_welcome_email_url( WP_User $user ) {
 
-			return wp_nonce_url( add_query_arg( array(
+			return esc_url(wp_nonce_url( add_query_arg( array(
 				'action'  => 'resend_welcome_email',
 				'user_id' => $user->ID
-			), '') , "send_welcome_email_{$user->ID}" );
+			), '') , "send_welcome_email_{$user->ID}" ));
 
 		}
 		


### PR DESCRIPTION
The send_welcome_email_url() function doesn't use esc_url() on the output of add_query_arg(), which is the suggested fix for plugins which were affected by the [WP 4.1.2 Security Release.](https://wordpress.org/news/2015/04/wordpress-4-1-2/) You do pass it to wp_nonce_url(), which uses esc_html(). But this may not be enough to address the security issue.

See this post for details: https://blog.sucuri.net/2015/04/security-advisory-xss-vulnerability-affecting-multiple-wordpress-plugins.html