### PR TITLE
Update for 4.3.1+ way of doing wp_new_user_notification()

### DIFF
--- a/resend-welcome-email.php
+++ b/resend-welcome-email.php
@@ -83,7 +83,7 @@ if ( !class_exists( 'Resend_Welcome_Email' )) {
 			
 			?>
 			<tr>
-				<th scope="row"><?php _e( 'Reset Password and Send Welcome Email',  'user-switching' ); ?></th>
+				<th scope="row"><?php _e( 'Resend Welcome Email',  'user-switching' ); ?></th>
 				<td><a href="<?php echo $link; ?>"><?php _e( 'Resend Welcome Email', 'user-switching' ); ?></a></td>
 			</tr>
 			<?php

--- a/resend-welcome-email.php
+++ b/resend-welcome-email.php
@@ -84,7 +84,7 @@ if ( !class_exists( 'Resend_Welcome_Email' )) {
 			?>
 			<tr>
 				<th scope="row"><?php _e( 'Reset Password and Send Welcome Email',  'user-switching' ); ?></th>
-				<td><a href="<?php echo $link; ?>"><?php _e( 'Reset Password and Send Welcome Email', 'user-switching' ); ?></a></td>
+				<td><a href="<?php echo $link; ?>"><?php _e( 'Resend Welcome Email', 'user-switching' ); ?></a></td>
 			</tr>
 			<?php
 		}

--- a/resend-welcome-email.php
+++ b/resend-welcome-email.php
@@ -144,13 +144,7 @@ if ( !class_exists( 'Resend_Welcome_Email' )) {
 				return false;
 			}
 			
-			// Generate a password
-			$password = substr(md5(uniqid(microtime())), 0, 7);
-			$user_info = get_userdata($user_id);
-
-			wp_update_user(array('ID' => $user_id, 'user_pass' => $password));
-	
-			wp_new_user_notification($user_id, $password);
+			wp_new_user_notification($user_id, null, 'both');
 
 		}
 		


### PR DESCRIPTION
In WP 4.3, wp_new_user_notification() stopped sending passwords via email, and instead it sends a reset password link. The 2nd argument to the function is deprecated. 

There's also no longer a point to setting a new password for the user before resending the welcome email, as they will be asked to set one.