### PR TITLE
Permission check bug

### DIFF
--- a/resend-welcome-email.php
+++ b/resend-welcome-email.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'Resend_Welcome_Email' ) ) {
 		public function __construct() {
 
 			/* Check user permission */
-			if ( ! current_user_can( 'edit_user' ) ) {
+			if ( ! current_user_can( 'edit_users' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Hi! Thanks for the plugin!
There is two different capabilites:
- edit_user and
- edit_users
The first one needs a user-id otherwise it will throw the Notice:
PHP Notice:  Undefined offset: 0 in /wp-includes/capabilities.php on line 53

Added an "s" :)